### PR TITLE
Bugfix/vehicle ui update (#27)

### DIFF
--- a/CommonUI/src/main/java/com/drivequant/drivekit/common/ui/graphical/DKColors.kt
+++ b/CommonUI/src/main/java/com/drivequant/drivekit/common/ui/graphical/DKColors.kt
@@ -6,7 +6,7 @@ open class DKColors {
     open fun primaryColor(): Int = Color.parseColor("#0B4D6E")
     open fun secondaryColor(): Int = Color.parseColor("#00EBB8")
     open fun mainFontColor(): Int = Color.parseColor("#161616")
-    open fun complementaryFontColor(): Int = Color.parseColor("#9E9E9E")
+    open fun complementaryFontColor(): Int = Color.parseColor("#555555")
     open fun fontColorOnPrimaryColor(): Int = Color.WHITE
     open fun fontColorOnSecondaryColor(): Int = Color.WHITE
     open fun neutralColor(): Int = Color.parseColor("#F0F0F0")

--- a/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/beacon/fragment/children/BeaconScannerInfoFragment.kt
+++ b/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/beacon/fragment/children/BeaconScannerInfoFragment.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.graphics.drawable.DrawableCompat
 import android.text.Spannable
 import android.view.LayoutInflater
 import android.view.View
@@ -50,41 +51,37 @@ class BeaconScannerInfoFragment : Fragment(), BeaconBatteryReaderListener {
         view_border.setBackgroundColor(DriveKitUI.colors.mainFontColor())
 
         val mainFontColor = DriveKitUI.colors.mainFontColor()
-        val primaryColor = DriveKitUI.colors.primaryColor()
         val neutralColor = DriveKitUI.colors.neutralColor()
 
         text_view_connected_vehicle_name.normalText(mainFontColor)
         text_view_connected_vehicle_name.typeface = Typeface.DEFAULT_BOLD
 
         if (isValid){
+            view_border.setBackgroundColor(DriveKitUI.colors.secondaryColor())
             text_view_connected_vehicle_name.text = viewModel.vehicleName?.let {
                 it
             }?:run {
                 DKResource.convertToString(requireContext(), "dk_beacon_vehicle_unknown")
             }
         } else {
-            val vehicle = viewModel.fetchVehicleFromSeenBeacon(
-                VehicleUtils().fetchVehiclesOrderedByDisplayName(requireContext())
-            )
-            vehicle?.let {
+            view_border.setBackgroundColor(DriveKitUI.colors.complementaryFontColor())
+            viewModel.fetchVehicleFromSeenBeacon(VehicleUtils().fetchVehiclesOrderedByDisplayName(requireContext()))?.let { vehicle ->
                 text_view_connected_vehicle_name.text = vehicle.buildFormattedName(requireContext())
             }
         }
 
-        button_beacon_info.setOnClickListener {
-            viewModel.launchDetailFragment()
-        }
+        configureInfoButton()
 
         view_separator.setBackgroundColor(neutralColor)
 
-        text_view_major_title.normalText(primaryColor)
+        text_view_major_title.normalText(DriveKitUI.colors.complementaryFontColor())
         text_view_major_title.text = DKResource.convertToString(requireContext(), "dk_beacon_major")
 
         text_view_major_value.normalText(mainFontColor)
         text_view_major_value.typeface = Typeface.DEFAULT_BOLD
         text_view_major_value.text = viewModel.seenBeacon?.major.toString()
 
-        text_view_minor_title.normalText(primaryColor)
+        text_view_minor_title.normalText(DriveKitUI.colors.complementaryFontColor())
         text_view_minor_title.text = DKResource.convertToString(requireContext(), "dk_beacon_minor")
 
         text_view_minor_value.normalText(mainFontColor)
@@ -106,6 +103,14 @@ class BeaconScannerInfoFragment : Fragment(), BeaconBatteryReaderListener {
             DKResource.convertToDrawable(requireContext(), "dk_beacon_signal_intensity")?.let { drawable ->
                 text_view_signal_intensity.setCompoundDrawablesRelativeWithIntrinsicBounds(null, drawable, null, null)
             }
+        }
+    }
+
+    private fun configureInfoButton(){
+        button_beacon_info.setImageDrawable(DKResource.convertToDrawable(requireContext(), "dk_common_info"))
+        DrawableCompat.setTint(button_beacon_info.drawable, DriveKitUI.colors.secondaryColor())
+        button_beacon_info.setOnClickListener {
+            viewModel.launchDetailFragment()
         }
     }
 
@@ -171,9 +176,10 @@ class BeaconScannerInfoFragment : Fragment(), BeaconBatteryReaderListener {
             })
             .append(" ")
             .append(unit, requireContext().resSpans {
-            color(mainFontColor)
-            typeface(Typeface.NORMAL)
-            size(R.dimen.dk_text_small)
-        }).toSpannable()
+                color(mainFontColor)
+                typeface(Typeface.NORMAL)
+                size(R.dimen.dk_text_small)
+            })
+            .toSpannable()
     }
 }

--- a/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/beacon/fragment/children/BeaconScannerNotFoundFragment.kt
+++ b/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/beacon/fragment/children/BeaconScannerNotFoundFragment.kt
@@ -12,6 +12,7 @@ import com.drivequant.drivekit.common.ui.extension.normalText
 import com.drivequant.drivekit.common.ui.extension.setDKStyle
 import com.drivequant.drivekit.common.ui.utils.DKResource
 import com.drivequant.drivekit.vehicle.ui.R
+import com.drivequant.drivekit.vehicle.ui.beacon.viewmodel.BeaconScanType
 import com.drivequant.drivekit.vehicle.ui.beacon.viewmodel.BeaconStep
 import com.drivequant.drivekit.vehicle.ui.beacon.viewmodel.BeaconViewModel
 import kotlinx.android.synthetic.main.fragment_beacon_child_scanner_not_found.*
@@ -43,17 +44,22 @@ class BeaconScannerNotFoundFragment : Fragment() {
             viewModel.updateScanState(BeaconStep.SCAN)
         }
 
-        button_cancel.button()
-        button_cancel.text = DKResource.convertToString(requireContext(), "dk_common_cancel")
-        button_cancel.setOnClickListener {
-            activity?.onBackPressed()
-        }
+        if (viewModel.scanType != BeaconScanType.PAIRING) {
+            button_cancel.visibility = View.GONE
+            button_abort.visibility = View.GONE
+        } else {
+            button_cancel.button()
+            button_cancel.text = DKResource.convertToString(requireContext(), "dk_common_cancel")
+            button_cancel.setOnClickListener {
+                activity?.onBackPressed()
+            }
 
-        button_abort.normalText(DriveKitUI.colors.secondaryColor())
-        button_abort.typeface = Typeface.DEFAULT_BOLD
-        button_abort.text = DKResource.convertToString(requireContext(), "dk_common_finish")
-        button_abort.setOnClickListener {
-            viewModel.scanValidationFinished()
+            button_abort.normalText(DriveKitUI.colors.secondaryColor())
+            button_abort.typeface = Typeface.DEFAULT_BOLD
+            button_abort.text = DKResource.convertToString(requireContext(), "dk_common_finish")
+            button_abort.setOnClickListener {
+                viewModel.scanValidationFinished()
+            }
         }
     }
 }

--- a/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/picker/adapter/ItemRecyclerViewAdapter.kt
+++ b/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/picker/adapter/ItemRecyclerViewAdapter.kt
@@ -60,12 +60,12 @@ class ItemRecyclerViewAdapter(
                 holder.textView.setBackgroundColor(DriveKitUI.colors.secondaryColor())
             }
             TEXT_IMAGE_ITEM -> {
-                holder.textView.normalText(DriveKitUI.colors.primaryColor())
+                holder.textView.normalText(DriveKitUI.colors.complementaryFontColor())
             }
             TEXT_OR_IMAGE_ITEM -> {
                 if (item.value.equals("OTHER_BRANDS", true)){
                     holder.textView.normalText()
-                    holder.textView.bigText(DriveKitUI.colors.primaryColor())
+                    holder.textView.bigText(DriveKitUI.colors.complementaryFontColor())
                 } else {
                     holder.textView.visibility = View.GONE
                 }

--- a/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/vehicledetail/fragment/VehicleDetailFragment.kt
+++ b/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/vehicledetail/fragment/VehicleDetailFragment.kt
@@ -133,7 +133,7 @@ class VehicleDetailFragment : Fragment() {
                 cameraFilePath = filePath
             }
         }
-        cameraFilePath = DriveKitSharedPreferencesUtils.getString(String.format("VEHICLE_PICTURE_PREF_%s", vehicleId))
+        cameraFilePath = DriveKitSharedPreferencesUtils.getString(String.format("drivekit-vehicle-picture_%s", vehicleId))
         imageView = activity?.findViewById(R.id.image_view_vehicle)
         imageView?.let {
             Glide.with(this)
@@ -335,7 +335,7 @@ class VehicleDetailFragment : Fragment() {
 
     private fun saveVehiclePictureLocalPath(path: String?){
         path?.let {
-            DriveKitSharedPreferencesUtils.setString(String.format("VEHICLE_PICTURE_PREF_%s", vehicleId), path)
+            DriveKitSharedPreferencesUtils.setString(String.format("drivekit-vehicle-picture_%s", vehicleId), path)
         }
     }
 

--- a/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/vehicles/utils/VehicleUtils.kt
+++ b/VehicleUI/src/main/java/com/drivequant/drivekit/vehicle/ui/vehicles/utils/VehicleUtils.kt
@@ -3,6 +3,7 @@ package com.drivequant.drivekit.vehicle.ui.vehicles.utils
 import android.content.Context
 import android.text.TextUtils
 import com.drivequant.drivekit.common.ui.utils.DKResource
+import com.drivequant.drivekit.databaseutils.Query
 import com.drivequant.drivekit.databaseutils.entity.Vehicle
 import com.drivequant.drivekit.vehicle.DriveKitVehicle
 import com.drivequant.drivekit.vehicle.ui.extension.buildFormattedName
@@ -11,7 +12,13 @@ import java.util.*
 open class VehicleUtils {
 
     fun fetchVehiclesOrderedByDisplayName(context: Context) : List<Vehicle> {
-        val sortedVehicles = DriveKitVehicle.vehiclesQuery().noFilter().query().execute().toMutableList()
+        val sortedVehicles = DriveKitVehicle.vehiclesQuery().noFilter()
+            .orderBy("brand", Query.Direction.ASCENDING)
+            .query()
+            .execute()
+            .sortedWith(compareBy(Vehicle::brand, Vehicle::model, Vehicle::version))
+            .toMutableList()
+
         sortedVehicles.sortWith(Comparator { vehicle1: Vehicle, vehicle2: Vehicle ->
             val vehicle1DisplayName = buildFormattedNameByPosition(context, vehicle1, sortedVehicles)
             val vehicle2DisplayName = buildFormattedNameByPosition(context, vehicle2, sortedVehicles)

--- a/VehicleUI/src/main/res/layout/activity_vehicle_picker.xml
+++ b/VehicleUI/src/main/res/layout/activity_vehicle_picker.xml
@@ -12,7 +12,8 @@
         <FrameLayout
             android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:layout_margin="@dimen/dk_margin_medium"/>
     </LinearLayout>
     <include android:id="@+id/dk_progress_circular" layout="@layout/dk_layout_progress_bar" />
 </FrameLayout>

--- a/VehicleUI/src/main/res/layout/fragment_beacon_child_scanner_info.xml
+++ b/VehicleUI/src/main/res/layout/fragment_beacon_child_scanner_info.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/dk_margin_half">
     <android.support.v7.widget.CardView
         xmlns:tools="http://schemas.android.com/tools"
         android:id="@+id/view_group_card_beacon_info"
@@ -32,14 +33,14 @@
                         android:layout_width="@dimen/dk_ic_big"
                         android:layout_height="@dimen/dk_ic_big"
                         android:layout_gravity="center_vertical"
-                        android:padding="@dimen/dk_margin_half"
-                        android:src="@drawable/dk_common_info"
-                        android:tint="@android:color/black"
+                        android:padding="@dimen/dk_margin_quarter"
                         android:foreground="?selectableItemBackground" />
                 </LinearLayout>
                 <View
                     android:id="@+id/view_separator"
-                    style="@style/Separator.Horizontal" />
+                    style="@style/Separator.Horizontal"
+                    android:layout_marginTop="@dimen/dk_margin_quarter"
+                    android:layout_marginBottom="@dimen/dk_margin_quarter" />
                 <LinearLayout style="@style/MW">
                     <LinearLayout
                         style="@style/MW"

--- a/VehicleUI/src/main/res/layout/fragment_beacon_detail.xml
+++ b/VehicleUI/src/main/res/layout/fragment_beacon_detail.xml
@@ -2,7 +2,7 @@
 <android.support.v7.widget.RecyclerView
     android:id="@+id/recycler_view_container"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical"
     xmlns:android="http://schemas.android.com/apk/res/android">
 </android.support.v7.widget.RecyclerView>

--- a/VehicleUI/src/main/res/layout/fragment_vehicle_category_description.xml
+++ b/VehicleUI/src/main/res/layout/fragment_vehicle_category_description.xml
@@ -5,8 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:focusable="true"
-    android:clickable="true"
-    android:background="#FFFFFF">
+    android:clickable="true">
 
     <ImageView
         android:id="@+id/image_view_icon2"

--- a/VehicleUI/src/main/res/layout/fragment_vehicle_name_chooser.xml
+++ b/VehicleUI/src/main/res/layout/fragment_vehicle_name_chooser.xml
@@ -4,8 +4,7 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:focusable="true"
-    android:clickable="true"
-    android:background="#FFFFFF">
+    android:clickable="true">
 
     <ImageView
         android:id="@+id/image_view"
@@ -20,7 +19,8 @@
         android:id="@+id/text_view_description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/dk_margin_half"
+        android:layout_marginTop="@dimen/dk_margin_half"
+        android:layout_marginBottom="@dimen/dk_margin_half"
         android:gravity="center"
         app:layout_constraintTop_toBottomOf="@id/image_view"
         app:layout_constraintStart_toStartOf="parent"
@@ -30,7 +30,8 @@
         android:id="@+id/text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/dk_margin_half"
+        android:layout_marginTop="@dimen/dk_margin_half"
+        android:layout_marginBottom="@dimen/dk_margin_half"
         android:padding="@dimen/dk_margin_half"
         app:layout_constraintTop_toBottomOf="@id/text_view_description"
         app:layout_constraintStart_toStartOf="parent"
@@ -46,7 +47,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/dk_margin_half"
-        android:padding="@dimen/dk_margin_half"
+        android:paddingTop="@dimen/dk_margin_half"
+        android:paddingBottom="@dimen/dk_margin_half"
         android:foreground="?attr/selectableItemBackgroundBorderless"
         app:layout_constraintTop_toBottomOf="@id/text_input_layout"
         app:layout_constraintStart_toStartOf="parent"

--- a/VehicleUI/src/main/res/layout/layout_item_text_image.xml
+++ b/VehicleUI/src/main/res/layout/layout_item_text_image.xml
@@ -2,8 +2,8 @@
 <android.support.v7.widget.CardView
     android:layout_width="match_parent"
     android:layout_height="150dp"
-    android:padding="4dp"
-    android:layout_margin="4dp"
+    android:padding="@dimen/dk_margin_quarter"
+    android:layout_margin="@dimen/dk_margin_quarter"
     card_view:cardBackgroundColor="#FFFFFF"
     android:focusable="true"
     android:foreground="?attr/selectableItemBackgroundBorderless"
@@ -12,20 +12,22 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/dk_margin_medium"
+        android:layout_marginEnd="@dimen/dk_margin_medium"
+        android:gravity="center"
         android:orientation="vertical">
         <ImageView
             android:id="@+id/image_view"
-            android:layout_width="104dp"
-            android:layout_height="104dp"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
             android:layout_weight="1"
+            android:layout_marginStart="@dimen/dk_margin_half"
+            android:layout_marginEnd="@dimen/dk_margin_half"
             android:layout_gravity="center_horizontal"/>
         <TextView android:id="@+id/text_view"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
+            android:layout_height="wrap_content"
             android:gravity="center"
-            android:layout_marginStart="@dimen/dk_margin_half"
-            android:layout_marginEnd="@dimen/dk_margin_half"
             android:layout_marginBottom="@dimen/dk_margin_half"
             android:layout_gravity="center_horizontal"/>
     </LinearLayout>

--- a/VehicleUI/src/main/res/values-fr/vehicle_data_strings.xml
+++ b/VehicleUI/src/main/res/values-fr/vehicle_data_strings.xml
@@ -103,7 +103,7 @@
    <string name="dk_vehicle_category_car_sport_description">Cette catégorie correspond à des véhicules dotés de motorisation, de châssis et de système de freinage axés sur la performance.</string>
    <string name="dk_vehicle_category_car_sport_title">Coupé</string>
    <string name="dk_vehicle_category_car_suv_description">Cette catégorie correspond aux véhicules de type Crossover (ou \"multisegment\") ou aux véhicules tout-terrains à transmission intégrale (4x4) et dont la longueur varie en moyenne de 4,10 à 5,20 m.</string>
-   <string name="dk_vehicle_category_car_suv_title">SUV</string>
+   <string name="dk_vehicle_category_car_suv_title">4X4, SUV, Crossover</string>
    <string name="dk_vehicle_category_display_brands">Continuer pour sélectionner la marque et le modèle de votre véhicule</string>
    <string name="dk_vehicle_configure_beacon_desc">Un beacon est déjà associé au véhicule %s</string>
    <string name="dk_vehicle_configure_beacon_title">Configurer le beacon</string>


### PR DESCRIPTION
* Fix vehicles order between two vehicles without custom name

* Change complementaryFontColor value

* Update layout spacing in VehiclePicker screens

* Remove cancel and abort item in beacon scan not found case

* Enchance vehicles list sort by brand model version, adjust beacon diag card

* Rename vehicle picture SharedPref

* Remove unused var

Co-authored-by: Steven THOMAS-BRONDEAU <steven.thomas-brondeau@drivequant.com>